### PR TITLE
An error in FC switch block / unblock scrip breaks XenCert tool

### DIFF
--- a/XenCert/blockunblockhbapaths-cisco
+++ b/XenCert/blockunblockhbapaths-cisco
@@ -60,7 +60,7 @@ if op == 'block':
     XenCertPrint("Blocking ports: %s" % sampled_portlist)
     retVal=ip + ':' + username + ':' + password + ':'
     
-    for port in sampled_portlist::
+for port in sampled_portlist:
     if op == 'block':
         blockUnblockPort(True, ip, username, password, port)
         retVal += port


### PR DESCRIPTION
XenCert scrips fails to configure cisco FC switch due to an error in the template script for cisco switch port enable/ disable. Fix corrects the python error.
