### PR TITLE
Exempt iscsi SR from fail path calculation, and make XenCert compatible with clearwater.

### DIFF
--- a/XenCert/StorageHandler.py
+++ b/XenCert/StorageHandler.py
@@ -320,9 +320,16 @@ class StorageHandler:
                         raise Exception("Failed to block paths.")
                     
                     XenCertPrint("Dev Path Config = '%s', no of Blocked switch Paths = '%s'" % (self.listPathConfig, self.noOfPaths))
-                    #Calculate the number of devices to be found after the path block
-                    devicesToFail = (len(self.listPathConfig)/self.noOfTotalPaths) * self.noOfPaths
-                    XenCertPrint("Expected devices to fail: %s" % devicesToFail)
+
+                    # Fail path calculation need not be done in case of iscsi SRs
+                    if self.storage_conf['pathHandlerUtil'].split('/')[-1] \
+                                               == "blockunblockiscsipaths":
+                        devicesToFail = self.noOfPaths
+                    else:
+                        #Calculate the number of devices to be found after the path block
+                        devicesToFail = (len(self.listPathConfig)/self.noOfTotalPaths) * self.noOfPaths
+                        XenCertPrint("Expected devices to fail: %s" % devicesToFail)
+
                     s = WaitForFailover(self.session, device_config['SCSIid'], len(self.listPathConfig), devicesToFail)
                     s.start()
                     


### PR DESCRIPTION
Made trunk XenCert compatabile with clearwater.
Also added code to excepted iscsi SR from fail path calculation when running multipath tests.
