### PR TITLE
CA-146872: Ensure diskdatatest uses absolute path

### DIFF
--- a/XenCert/StorageHandler.py
+++ b/XenCert/StorageHandler.py
@@ -22,6 +22,7 @@ from StorageHandlerUtil import Print
 from StorageHandlerUtil import PrintOnSameLine
 from StorageHandlerUtil import XenCertPrint
 from StorageHandlerUtil import displayOperationStatus
+from StorageHandlerUtil import DISKDATATEST
 from srmetadata import SLMetadataHandler
 import scsiutil, iscsilib
 import XenAPI
@@ -2301,11 +2302,11 @@ class StorageHandlerISCSI(StorageHandler):
                             cmd = ['dd', 'if=/dev/zero', 'of=%s' % tuple[2], 'bs=1M', 'count=1', 'conv=nocreat', 'oflag=direct']
                             util.pread(cmd)
                                                         
-                            cmd = ['./diskdatatest', 'write', '1', tuple[2]]
+                            cmd = [DISKDATATEST, 'write', '1', tuple[2]]
                             XenCertPrint("The command to be fired is: %s" % cmd)
                             util.pread(cmd)
                             
-                            cmd = ['./diskdatatest', 'verify', '1', tuple[2]]
+                            cmd = [DISKDATATEST, 'verify', '1', tuple[2]]
                             XenCertPrint("The command to be fired is: %s" % cmd)
                             util.pread(cmd)
                             
@@ -2654,11 +2655,11 @@ class StorageHandlerHBA(StorageHandler):
                             cmd = ['dd', 'if=/dev/zero', 'of=%s' % device, 'bs=1M', 'count=1', 'conv=nocreat', 'oflag=direct']
                             util.pread(cmd)
 
-                            cmd = ['./diskdatatest', 'write', '1', device]
+                            cmd = [DISKDATATEST, 'write', '1', device]
                             XenCertPrint("The command to be fired is: %s" % cmd)
                             util.pread(cmd)
                             
-                            cmd = ['./diskdatatest', 'verify', '1', device]
+                            cmd = [DISKDATATEST, 'verify', '1', device]
                             XenCertPrint("The command to be fired is: %s" % cmd)
                             util.pread(cmd)
                             

--- a/XenCert/StorageHandlerUtil.py
+++ b/XenCert/StorageHandlerUtil.py
@@ -53,6 +53,8 @@ BUF_PATTERN = CHAR_SEQ + CHAR_SEQ
 BUF_PATTERN_REV = CHAR_SEQ_REV + CHAR_SEQ_REV
 BUF_ZEROS = "\0" * 512
 
+DISKDATATEST = '/opt/xensource/debug/XenCert/diskdatatest'
+
 multiPathDefaultsMap = { 'udev_dir':'/dev',
 			    'polling_interval':'5',
 			    'selector': "round-robin 0",
@@ -850,7 +852,7 @@ def FindDiskDataTestEstimate(device, size):
     estimatedTime = 0
     # Run diskdatatest in a report mode
     XenCertPrint("Run diskdatatest in a report mode with device %s to find the estimated time." % device)
-    cmd = ['./diskdatatest', 'report', '1', device]
+    cmd = [DISKDATATEST, 'report', '1', device]
     XenCertPrint("The command to be fired is: %s" % cmd)
     (rc, stdout, stderr) = util.doexec(cmd)
     if rc == 0:


### PR DESCRIPTION
Prior to this path, diskdatatests were using relative paths and run
under the assumption that tests would always be executed from XenCert's
root directory which caused a bunch of failures. This path should switch
the diskdatatests to use the absolute path.

Signed-off-by: Siddharth Vinothkumar siddharth.vinothkumar@citrix.com
