### PR TITLE
CA-148550: Skip direct flag while doing sample write to VDI

### DIFF
--- a/XenCert/StorageHandlerUtil.py
+++ b/XenCert/StorageHandlerUtil.py
@@ -596,7 +596,7 @@ def Detach_VDI(session, vdi_ref):
 def FindTimeToWriteData(devicename, sizeInMiB):
     ddOutFile = 'of=' + devicename
     XenCertPrint("Now copy %dMiB data from /dev/zero to this device and record the time taken to copy it." % sizeInMiB)
-    cmd = ['dd', 'if=/dev/zero', ddOutFile, 'bs=4096', 'count=%d' % (sizeInMiB * 256), 'oflag=direct']
+    cmd = ['dd', 'if=/dev/zero', ddOutFile, 'bs=4096', 'count=%d' % (sizeInMiB * 256)]
     try:
 	(rc, stdout, stderr) = util.doexec(cmd,'')
 	list = stderr.split('\n')


### PR DESCRIPTION
The direct flag used in the sample write can cause tests to fail because it takes a very long time to complete. This can be omitted as the actual write (spanning the length of the VDI) doesn't use this flag. 

Signed-off-by: Chandrika Srinivasan chandrika.srinivasan@citrix.com
