### PR TITLE
CA-148436: Removed SR probing from iSCSI tests

### DIFF
--- a/XenCert/StorageHandler.py
+++ b/XenCert/StorageHandler.py
@@ -1810,7 +1810,6 @@ class StorageHandlerISCSI(StorageHandler):
         retVal = True
         retVal = self.metadata_sr_attach_tests() and \
             self.metadata_sr_scan_tests() and \
-            self.metadata_sr_probe_tests() and \
             self.metadata_sr_update_tests() and \
             self.metadata_general_vm_tests() and \
             self.metadata_scalibility_tests() and \


### PR DESCRIPTION
Probing is broken for reasons yet to investigate further.
Removing for the time being

Signed-off-by: Germano Percossi germano.percossi@citrix.com
