### PR TITLE
CA-144196: Disable multipathing after SR stack is cleaned up

### DIFF
--- a/XenCert/StorageHandler.py
+++ b/XenCert/StorageHandler.py
@@ -399,10 +399,6 @@ class StorageHandler:
                         checkPoint += 1
 
             Print("- Test succeeded.")
-
-            # If multipath was enabled by us, disable it, else continue.
-            if disableMP:
-                StorageHandlerUtil.disable_multipathing(self.session, util.get_localhost_uuid(self.session))
  
         except Exception, e:
             Print("- There was an exception while performing multipathing configuration tests.")
@@ -426,6 +422,10 @@ class StorageHandler:
             if sr_ref != None:
                 Print("      Destroy the SR.")
                 StorageHandlerUtil.DestroySR(self.session, sr_ref)
+
+            # If multipath was enabled by us, disable it, else continue.
+            if disableMP:
+                StorageHandlerUtil.disable_multipathing(self.session, util.get_localhost_uuid(self.session))
                 
             checkPoint += 1
                 


### PR DESCRIPTION
XenCert enables multipathing on the host before running the multipath
verification tests and creates a multipathed SR. However, multipathing
is disabled before the SR is deleted which leads to errors while cleaning
up the storage stack. Multipathing should be disabled after SR deletion.

Signed-off-by: Chandrika Srinivasan <chandrika.srinivasan@citrix.com>