### PR TITLE
CA-180090: XenCert wiping the root disk

### DIFF
--- a/XenCert/XenCertCommon.py
+++ b/XenCert/XenCertCommon.py
@@ -40,7 +40,8 @@ __cifs_args__ = [
     ["password", "The password to be used during CIFS authentication", " : ", None, "required", "-p", "" ] ]
 
 __lvmohba_args__ = [
-    ["adapters",       "comma separated list of HBAs to test against", " : ", None,        "optional", "-a", ""   ] ]
+    ["adapters",       "comma separated list of HBAs to test against", " : ", None,        "optional", "-a", ""   ],
+    ["scsiIDs",       "comma separated list of SCSI-IDs to test against", " : ", None,        "required", "-S", ""   ] ]
 
 __isl_args__ = [
     ["file",       "configuration file describing target array paramters", " : ", None,        "required", "-F", ""   ] ]


### PR DESCRIPTION
Root disk and HA-SR gets wiped by XenCert while executing disk IO tests
under functional tests. As a fix, SCSI-IDs for which disk IO tests has to
be performed must be passed as a command line argument (-S switch) for HA_SRs.

Signed-off-by: Sharath Babu <sharath.babu@citrix.com>