### PR TITLE
CA-166984: XenCertHBA: Failure to find path status in multipath tests

### DIFF
--- a/XenCert/StorageHandlerUtil.py
+++ b/XenCert/StorageHandlerUtil.py
@@ -59,7 +59,7 @@ multiPathDefaultsMap = { 'udev_dir':'/dev',
 			    'polling_interval':'5',
 			    'selector': "round-robin 0",
 			    'path_grouping_policy':'failover',
-			    'getuid_callout':"/sbin/scsi_id -g -u -s /block/%n",
+			    'getuid_callout':"/usr/lib/udev/scsi_id --whitelisted --replace-whitespace /dev/%n",
 			    'prio_callout':'none',
 			    'path_checker':'readsector0',
 			    'rr_min_io':'1000',
@@ -211,10 +211,7 @@ def GetConfig(scsiid):
 	configMap = {}
 	device = scsiutil._genReverseSCSIidmap(scsiid)[0]
 	XenCertPrint("GetConfig - device: %s" % device)
-	list = device.split('/')[1]
-	justDev = device.split('/')[2]
-	XenCertPrint("GetConfig - just the device: %s" % justDev)
-	cmd = ["scsi_id", "-u", "-g", "-x", "-s", "/block/%s" % justDev, "-d", device]
+	cmd = ["/usr/lib/udev/scsi_id", "--replace-whitespace", "--whitelisted", "--export", device]
 	ret = util.pread2(cmd)
 	XenCertPrint("GetConfig - scsi_if output: %s" % ret)
 	for tuple in ret.split('\n'):


### PR DESCRIPTION
With this change, the multipath tests get much further:

[root@cl05-02 XenCert]# /opt/xensource/debug/XenCert/XenCert -m -b lvmohba -g 100 -a host6,host5,host4 -u /opt/xensource/debug/XenCert/blockunblockhbapaths -i 10.219.130.81:admin:xenroot02T:4,8,5,9
********************** Welcome to XenCert 2.5 BUILD_NUMBER='107990c' *****************
Test start time: Thu Oct 29 14:39:51 2015
***********************************************************************
Performing multipath configuration verification.
CREATING SR
      Creating the SR.
                                                                                                   PASS [Completed]
                                                                                                   PASS [Completed]
MULTIPATH AUTOMATED PATH FAILOVER TESTING
>> Multipathd enabled for NETAPP, LUN with the following config:
     device {
             polling_interval 5
             path_checker "tur"
             product LUN.*
             vendor NETAPP
             features "2 pg_init_retries 50"
             prio "ontap"
             rr_min_io 128
             flush_on_last_del "yes"
             bindings_file /var/lib/multipath/bindings
             path_grouping_policy "group_by_prio"
             rr_weight "uniform"
             getuid_callout /usr/lib/udev/scsi_id --whitelisted --replace-whitespace /dev/%n
             retain_attached_hw_handler yes
             hardware_handler "0"
             no_path_retry "fail"
             udev_dir /dev
             user_friendly_names no
             detect_prio yes
             selector round-robin 0
             failback immediate
             prio_callout none
     }
>> Starting Random Path Block and Restore Iteration test
   This test will choose a random selection of upto (n -1) paths 
   of a total of n to block, and verify that the IO continues
   i.e. the correct paths are detected as failed, within 50 seconds.
   The test then verifies that after unblocking the path, it is 
   restored within 2 minutes.


   Path Connectivity Details
       HBTL            Path DM status            Path status    
       4:0:2:4         active                    ready          
       5:0:3:4         active                    ready          
       6:0:2:4         active                    ready          
   Create a VDI on the SR of the maximum available size.
                                                                                                   PASS [Completed]
   Create a VBD on this VDI and plug it into dom0
                                                                                                   PASS [Completed]

Iteration 1:

 -> No manual blocking of paths.
    - IO test passed. Time:  0.0100956 s. Data: 1MB. Throughput:  104 MB/s
                                                                                                   PASS [Completed]
Iteration 2:

 -> Blocking paths (10.219.130.81:admin:xenroot02T:9)
    - Paths failover time: 1 seconds
    - Maximum IO completion time:  4.40181 s. Data: 1MB. Throughput:  238 kB/s
                                                                                                   PASS [Completed]
 -> Unblocking paths, waiting for restoration.
                                                                                                   PASS [Completed 3 seconds]
Iteration 3:

 -> Blocking paths (10.219.130.81:admin:xenroot02T:9)
    - Paths failover time: 1 seconds
    - Maximum IO completion time:  4.40185 s. Data: 1MB. Throughput:  238 kB/s
                                                                                                   PASS [Completed]
 -> Unblocking paths, waiting for restoration.
                                                                                                   PASS [Completed 3 seconds]
Iteration 4:

 -> Blocking paths (10.219.130.81:admin:xenroot02T:4,9)
    - Paths failover time: 1 seconds
    - Maximum IO completion time:  4.40352 s. Data: 1MB. Throughput:  238 kB/s
                                                                                                   PASS [Completed]
 -> Unblocking paths, waiting for restoration.
                                                                                                   PASS [Completed 7 seconds]
Iteration 5:

 -> Blocking paths (10.219.130.81:admin:xenroot02T:4,5,8)
    - Paths failover time: 1 seconds
    - Maximum IO completion time:  0.0222889 s. Data: 1MB. Throughput:  47.0 MB/s
                                                                                                   PASS [Completed]
 -> Unblocking paths, waiting for restoration.
                                                                                                   PASS [Completed 1 seconds]
Iteration 6:

 -> Blocking paths (10.219.130.81:admin:xenroot02T:4,8)
    - Paths failover time: 1 seconds
    - Maximum IO completion time:  0.0186981 s. Data: 1MB. Throughput:  56.1 MB/s
                                                                                                   PASS [Completed]
 -> Unblocking paths, waiting for restoration.
                                                                                                   PASS [Completed 1 seconds]
Iteration 7:

 -> Blocking paths (10.219.130.81:admin:xenroot02T:4,8)
    - Paths failover time: 1 seconds
    - Maximum IO completion time:  0.0118779 s. Data: 1MB. Throughput:  88.3 MB/s
                                                                                                   PASS [Completed]
 -> Unblocking paths, waiting for restoration.
                                                                                                   PASS [Completed 1 seconds]
Iteration 8:

 -> Blocking paths (10.219.130.81:admin:xenroot02T:4,5,8)
                                                                                                   FAIL [Thu Oct 29 14:45:57 2015]
- There was an exception while performing multipathing configuration tests.
  Exception:     - Paths did not failover within expected time.
                                                                                                   FAIL [Thu Oct 29 14:46:24 2015]
      Destroy the SR.
                                                                                                   PASS [Completed]
***********************************************************************
***********************************************************************
Multipath configuration verification results      : FAIL, Pass percentage: 90, Completed: Thu Oct 29 14:46:56 2015
***********************************************************************
End of XenCert certification suite.
Please find the report for this test run at: /tmp/XenCert-6a36e098-9f08-439e-8a6b-091e4a73b2e7.log
***********************************************************************
Test end time: Thu Oct 29 14:46:56 2015
Execution time: 7 minutes, 5 seconds.
***********************************************************************
[root@cl05-02 XenCert]# 
