### PR TITLE
CA-393422: thread.isAlive() is deprecated since python3.9

### DIFF
--- a/src/XenCert/StorageHandler.py
+++ b/src/XenCert/StorageHandler.py
@@ -365,7 +365,7 @@ class StorageHandler(object):
                     s = WaitForFailover(self.session, device_config['SCSIid'], len(self.listPathConfig), devices_to_fail, checkfunc)
                     s.start()
 
-                    while s.isAlive():
+                    while s.is_alive():
                         timeTaken = 0
                         s1 = TimedDeviceIO(self.session.xenapi.VBD.get_device(vbd_ref))
                         s1.start()


### PR DESCRIPTION
Use is_alive instead to work in XS9 (python3.11)
'is_alive' is also supported in python3.6 which is good for XS8. https://docs.python.org/3.6/library/threading.html

Test job: 4018853