### PR TITLE
CP-312888 Switch HBA port block/unblock scripts from telnet to SSH

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# These helper scripts execute in XenServer Dom0 (Linux). A CRLF line ending
+# corrupts the shebang (env: 'python3\r': No such file or directory), so they
+# must always be checked out with LF endings regardless of platform.
+*.sh                        text eol=lf
+*.py                        text eol=lf
+src/XenCert/XenCert         text eol=lf
+src/XenCert/blockunblock*   text eol=lf

--- a/docs/xenserver-xencert-guide.md
+++ b/docs/xenserver-xencert-guide.md
@@ -342,41 +342,31 @@ Subsequently, the paths can be brought online as follows:
 
 ##### HBA storage type  
 
-The scripts to block and unblock paths for HBA storage type would be vendor specific. A sample script to bring down a qlogic port has been pasted below: 
+The scripts to block and unblock paths for HBA storage type would be vendor specific. The switch is accessed over SSH, using `sshpass` to supply the password non-interactively. A sample script to bring down a qlogic port has been pasted below: 
 ```
     #!/bin/bash
-    ( echo open <qlogic switch name>
-     sleep 5
-     echo <switch username>
-     sleep 1
-     echo <switch password>
-     sleep 1
-     echo admin start
-     sleep 1
-     echo set port <Post number> state offline
-     sleep 1
-     echo admin stop
-     sleep 1
-     echo quit
-    ) | telnet
+    ( echo "admin start";                        sleep 1
+      echo "set port <Port number> state offline"; sleep 1
+      echo "admin stop";                         sleep 1
+      echo "quit"
+    ) | sshpass -p <switch password> ssh -tt -o StrictHostKeyChecking=no \
+                                             -o UserKnownHostsFile=/dev/null \
+                                             -o HostKeyAlgorithms=+ssh-rsa,rsa-sha2-256,rsa-sha2-512 \
+                                             -o ConnectTimeout=10 \
+                                             <switch username>@<qlogic switch name>
 
     Similarly to bring a path back up use:
 
     #!/bin/bash
-    ( echo open <qlogic switch name>
-      sleep 5
-      echo <switch username>
-      sleep 1
-      echo <switch password>
-      sleep 1
-      echo admin start
-      sleep 1
-      echo set port <Post number> state online
-      sleep 1
-      echo admin stop
-      sleep 1
-      echo quit
-     ) | telnet  
+    ( echo "admin start";                       sleep 1
+      echo "set port <Port number> state online"; sleep 1
+      echo "admin stop";                        sleep 1
+      echo "quit"
+    ) | sshpass -p <switch password> ssh -tt -o StrictHostKeyChecking=no \
+                                             -o UserKnownHostsFile=/dev/null \
+                                             -o HostKeyAlgorithms=+ssh-rsa,rsa-sha2-256,rsa-sha2-512 \
+                                             -o ConnectTimeout=10 \
+                                             <switch username>@<qlogic switch name>
 ```
 
 ### Appendix B-Notes on storage discovery  
@@ -657,62 +647,40 @@ blockunblockHBAport.sh ip username password port portenable
 5.Set the ‘/xencert/block-unblock-over’ entry in XenStore to ‘1’ and exit.   
 
 ##### blockunblockHBAport.sh.brocade
-This sample script telnets to a brocade switch and brings ports up or down. The script is packaged with the kit, and looks like:
+This sample script connects to a brocade switch over SSH and brings ports up or down. The script is packaged with the kit, and looks like:
 ```
 #!/bin/bash
-( echo open ${1}
-  sleep 5
-  echo ${2}
-  sleep 1
-  echo ${3}
-  sleep 1
-  echo ${5} ${4}
-  sleep 1
-  sleep 1
-  echo exit 
- ) | telnet
+sshpass -p "${3}" ssh -o StrictHostKeyChecking=no \
+                      -o UserKnownHostsFile=/dev/null \
+                      -o HostKeyAlgorithms=+ssh-rsa,rsa-sha2-256,rsa-sha2-512 \
+                      -o ConnectTimeout=10 \
+                      "${2}@${1}" "${5} ${4}"
 ```
 ##### blockunblockHBAport.sh.qlogic
-This sample script telnets to a QLogic SANbox switch and brings ports up or down. The script is packaged with the kit, and looks like:
+This sample script connects to a QLogic SANbox switch over SSH and brings ports up or down. The script is packaged with the kit, and looks like:
 
         #!/bin/bash
-        ( echo open ${1}
-          sleep 5
-          echo ${2}
-          sleep 1
-          echo ${3}
-          sleep 1
-          echo admin start
-          sleep 1
-          echo set port ${4} state ${5}
-          sleep 1
-          echo admin stop
-          sleep 1
-          echo quit 
-         ) | telnet
+        ( echo "admin start";              sleep 1
+          echo "set port ${4} state ${5}"; sleep 1
+          echo "admin stop";               sleep 1
+          echo "quit"
+        ) | sshpass -p "${3}" ssh -tt -o StrictHostKeyChecking=no \
+                                      -o UserKnownHostsFile=/dev/null \
+                                      -o HostKeyAlgorithms=+ssh-rsa,rsa-sha2-256,rsa-sha2-512 \
+                                      -o ConnectTimeout=10 \
+                                      "${2}@${1}"
 
 
 ##### blockunblockHBAport.sh.cisco  
 
-This sample script telnets to a cisco switch and brings ports up or down. The script is packaged with the kit, and looks like:  
+This sample script connects to a cisco switch over SSH and brings ports up or down. The script is packaged with the kit, and looks like:  
 
          #!/bin/bash
-         ( echo open ${1}
-           sleep 5
-           echo ${2}
-           sleep 1
-           echo ${3}
-           sleep 1
-           echo config t
-           sleep 1
-           echo int fc1/${4}
-           sleep 1
-           echo ${5}
-           sleep 1
-           cho exit
-          sleep 1
-           echo quit 
-          ) | telnet  
+         sshpass -p "${3}" ssh -o StrictHostKeyChecking=no \
+                               -o UserKnownHostsFile=/dev/null \
+                               -o HostKeyAlgorithms=+ssh-rsa,rsa-sha2-256,rsa-sha2-512 \
+                               -o ConnectTimeout=10 \
+                               "${2}@${1}" "configure terminal ; interface fc1/${4} ; ${5} ; end"
 
  
 

--- a/src/XenCert/blockunblockHBAPort-brocade.sh
+++ b/src/XenCert/blockunblockHBAPort-brocade.sh
@@ -16,15 +16,12 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-( echo open ${1}
-  sleep 5
-  echo ${2}
-  sleep 1
-  echo ${3}
-  sleep 1
-  echo ${5} ${4}
-  sleep 1
-  sleep 1
-  echo exit 
- ) | telnet
+# Log in to the switch over SSH (username on the command line, password via
+# sshpass) and run the port enable/disable command. ${5} is portdisable/
+# portenable and ${4} is the port number.
+sshpass -p "${3}" ssh -o StrictHostKeyChecking=no \
+                      -o UserKnownHostsFile=/dev/null \
+                      -o HostKeyAlgorithms=+ssh-rsa,rsa-sha2-256,rsa-sha2-512 \
+                      -o ConnectTimeout=10 \
+                      "${2}@${1}" "${5} ${4}"
 

--- a/src/XenCert/blockunblockHBAPort-cisco.sh
+++ b/src/XenCert/blockunblockHBAPort-cisco.sh
@@ -16,20 +16,15 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-( echo open ${1}
-  sleep 5
-  echo ${2}
-  sleep 1
-  echo ${3}
-  sleep 1
-  echo config t
-  sleep 1
-  echo int fc1/${4}
-  sleep 1
-  echo ${5}
-  sleep 1
-  echo exit
-  sleep 1
-  echo quit 
- ) | telnet
+# Log in to the switch over SSH (username on the command line, password via
+# sshpass) and run the config as a single non-interactive exec line. NX-OS
+# accepts ";"-separated commands, so no pseudo-tty is needed; this avoids the
+# SSH session hanging until the switch's exec-timeout when XenCert invokes the
+# script without a controlling terminal. ${4} is the port number and ${5} is
+# shut/no shut.
+sshpass -p "${3}" ssh -o StrictHostKeyChecking=no \
+                      -o UserKnownHostsFile=/dev/null \
+                      -o HostKeyAlgorithms=+ssh-rsa,rsa-sha2-256,rsa-sha2-512 \
+                      -o ConnectTimeout=10 \
+                      "${2}@${1}" "configure terminal ; interface fc1/${4} ; ${5} ; end"
 

--- a/src/XenCert/blockunblockHBAPort-qlogic.sh
+++ b/src/XenCert/blockunblockHBAPort-qlogic.sh
@@ -16,18 +16,18 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-( echo open ${1}
-  sleep 5
-  echo ${2}
-  sleep 1
-  echo ${3}
-  sleep 1
-  echo admin start
-  sleep 1
-  echo set port ${4} state ${5}
-  sleep 1
-  echo admin stop
-  sleep 1
-  echo quit 
- ) | telnet
+# Log in to the switch over SSH (username on the command line, password via
+# sshpass) and feed the admin commands one at a time. "ssh -tt" forces a tty so
+# the switch CLI behaves interactively, and the sleeps give it time to process
+# each command (notably the admin start/stop transitions). ${4} is the port
+# number and ${5} is the port state (online/offline).
+( echo "admin start";              sleep 1
+  echo "set port ${4} state ${5}"; sleep 1
+  echo "admin stop";               sleep 1
+  echo "quit"
+) | sshpass -p "${3}" ssh -tt -o StrictHostKeyChecking=no \
+                              -o UserKnownHostsFile=/dev/null \
+                              -o HostKeyAlgorithms=+ssh-rsa,rsa-sha2-256,rsa-sha2-512 \
+                              -o ConnectTimeout=10 \
+                              "${2}@${1}"
 

--- a/src/XenCert/blockunblockhbapaths-brocade
+++ b/src/XenCert/blockunblockhbapaths-brocade
@@ -58,7 +58,9 @@ portList = sys.argv[3].split(':')[3].split(',')
 sampled_portlist = portList
 
 if op == 'block':
-    sampled_portlist = random.sample(portList, random.randint(1, len(portList) - 1))
+    # Block a random subset; keep at least one port up when several are given.
+    # max(1, ...) also allows a single-port list (one HBA per switch, dual-fabric).
+    sampled_portlist = random.sample(portList, random.randint(1, max(1, len(portList) - 1)))
     xencert_print("Blocking ports: %s" % sampled_portlist)
     retVal=ip + ':' + username + ':' + password + ':'
 

--- a/src/XenCert/blockunblockhbapaths-cisco
+++ b/src/XenCert/blockunblockhbapaths-cisco
@@ -58,7 +58,9 @@ portList = sys.argv[3].split(':')[3].split(',')
 sampled_portlist = portList
 
 if op == 'block':
-    sampled_portlist = random.sample(portList, random.randint(1, len(portList) - 1))
+    # Block a random subset; keep at least one port up when several are given.
+    # max(1, ...) also allows a single-port list (one HBA per switch, dual-fabric).
+    sampled_portlist = random.sample(portList, random.randint(1, max(1, len(portList) - 1)))
     xencert_print("Blocking ports: %s" % sampled_portlist)
     retVal=ip + ':' + username + ':' + password + ':'
     

--- a/src/XenCert/blockunblockhbapaths-qlogic
+++ b/src/XenCert/blockunblockhbapaths-qlogic
@@ -58,7 +58,9 @@ portList = sys.argv[3].split(':')[3].split(',')
 sampled_portlist = portList
 
 if op == 'block':
-    sampled_portlist = random.sample(portList, random.randint(1, len(portList) - 1))
+    # Block a random subset; keep at least one port up when several are given.
+    # max(1, ...) also allows a single-port list (one HBA per switch, dual-fabric).
+    sampled_portlist = random.sample(portList, random.randint(1, max(1, len(portList) - 1)))
     xencert_print("Blocking ports: %s" % sampled_portlist) 
     retVal=ip + ':' + username + ':' + password + ':'
     


### PR DESCRIPTION
XS9 does not ship a telnet client, so the blockunblockHBAPort-*.sh scripts can no longer reach the FC switches over telnet. Use SSH instead, with sshpass supplying the password non-interactively (sshpass built/installed via CP-312931). SSH handles authentication, so the login-handshake sleeps are dropped; cisco/qlogic keep the inter-command sleeps via "ssh -tt" + a piped subshell to preserve pacing for mode transitions. Update the user guide samples (Appendix A and C) to match.